### PR TITLE
fix: dont use existing object for example pairings fallback

### DIFF
--- a/src/Documentation.test.tsx
+++ b/src/Documentation.test.tsx
@@ -7,3 +7,9 @@ it("renders without crashing", () => {
   ReactDOM.render(<Documentation schema={{} as any}/>, div);
   ReactDOM.unmountComponentAtNode(div);
 });
+
+it("renders without crashing with no schema", () => {
+  const div = document.createElement("div");
+  ReactDOM.render(<Documentation />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/src/Documentation.tsx
+++ b/src/Documentation.tsx
@@ -6,7 +6,7 @@ import ContentDescriptors from "./ContentDescriptors/ContentDescriptors";
 import { OpenrpcDocument } from "@open-rpc/meta-schema";
 
 interface IProps {
-  schema: OpenrpcDocument;
+  schema?: OpenrpcDocument;
   uiSchema?: any;
   reactJsonOptions?: any;
   methodPlugins?: Array<React.FC<IMethodPluginProps>>;

--- a/src/ExamplePairings/ExamplePairings.test.tsx
+++ b/src/ExamplePairings/ExamplePairings.test.tsx
@@ -113,7 +113,53 @@ it("renders examples with only schema examples with no params", async () => {
       } />
     , div);
   expect(div.innerHTML.includes("potato")).toBe(true);
+  expect(div.innerHTML.includes("bob")).toBe(false);
+  ReactDOM.unmountComponentAtNode(div);
+});
+
+it("renders examples with multiple param schema examples and no method", async () => {
+  const div = document.createElement("div");
+  const testDoc: OpenrpcDocument = {
+    info: {
+      title: "test",
+      version: "0.0.0",
+    },
+    methods: [
+      {
+        name: "test-method",
+        params: [
+          {
+            name: "testparam1",
+            schema: {
+              examples: ["bob"],
+              type: "string",
+            },
+          },
+          {
+            name: "testparam2",
+            schema: {
+              examples: ["bob2"],
+              type: "string",
+            },
+          },
+        ],
+        result: {
+          name: "test-method-result",
+          schema: {
+            examples: ["potato"],
+            type: "string",
+          },
+        },
+      },
+    ],
+    openrpc: "1.0.0",
+  };
+  ReactDOM.render(
+    <ExamplePairings method={testDoc.methods[0]} />
+    , div);
+  console.log("div", div.innerHTML); //tslint:disable-line
   expect(div.innerHTML.includes("bob")).toBe(true);
+  expect(div.innerHTML.includes("bob2")).toBe(true);
   ReactDOM.unmountComponentAtNode(div);
 });
 
@@ -132,6 +178,42 @@ it("renders examples with only schema examples and no method", async () => {
           schema: {
             examples: ["bob"],
             type: "string",
+          },
+        }],
+        result: {
+          name: "test-method-result",
+          schema: {
+            examples: ["potato"],
+            type: "string",
+          },
+        },
+      },
+    ],
+    openrpc: "1.0.0",
+  };
+  ReactDOM.render(
+    <ExamplePairings
+      examples={testDoc.methods[0].examples as ExamplePairingObject[]
+      } />
+    , div);
+  ReactDOM.unmountComponentAtNode(div);
+});
+
+it("renders examples with only schema examples and no method with number", async () => {
+  const div = document.createElement("div");
+  const testDoc: OpenrpcDocument = {
+    info: {
+      title: "test",
+      version: "0.0.0",
+    },
+    methods: [
+      {
+        name: "test-method",
+        params: [{
+          name: "testparam1",
+          schema: {
+            examples: [10101],
+            type: "number",
           },
         }],
         result: {

--- a/src/ExamplePairings/ExamplePairings.test.tsx
+++ b/src/ExamplePairings/ExamplePairings.test.tsx
@@ -234,6 +234,41 @@ it("renders examples with only schema examples and no method with number", async
     , div);
   ReactDOM.unmountComponentAtNode(div);
 });
+it("renders examples with only schema examples and no method with multiple number examples", async () => {
+  const div = document.createElement("div");
+  const testDoc: OpenrpcDocument = {
+    info: {
+      title: "test",
+      version: "0.0.0",
+    },
+    methods: [
+      {
+        name: "test-method",
+        params: [{
+          name: "testparam1",
+          schema: {
+            examples: [10101, 102],
+            type: "number",
+          },
+        }],
+        result: {
+          name: "test-method-result",
+          schema: {
+            examples: ["potato", "bar"],
+            type: "string",
+          },
+        },
+      },
+    ],
+    openrpc: "1.0.0",
+  };
+  ReactDOM.render(
+    <ExamplePairings
+      examples={testDoc.methods[0].examples as ExamplePairingObject[]
+      } />
+    , div);
+  ReactDOM.unmountComponentAtNode(div);
+});
 
 it("renders examples and can switch between them", async () => {
   const simpleMath = await refParser.dereference(examples.simpleMath) as OpenrpcDocument;

--- a/src/ExamplePairings/ExamplePairings.tsx
+++ b/src/ExamplePairings/ExamplePairings.tsx
@@ -15,15 +15,6 @@ interface IState {
   currentExample?: ExamplePairingObject;
 }
 
-const newExample: ExamplePairingObject = {
-  name: "generated-example",
-  params: [
-  ],
-  result: {
-    name: "example-result",
-    value: null,
-  },
-};
 const getExamplesFromMethod = (method?: MethodObject): ExamplePairingObject[] => {
   if (!method) { return []; }
   if (!method.params) { return []; }
@@ -33,12 +24,25 @@ const getExamplesFromMethod = (method?: MethodObject): ExamplePairingObject[] =>
     if (param.schema && param.schema.examples && param.schema.examples.length > 0) {
       param.schema.examples.forEach((ex: any, i: number) => {
         if (!examples[i]) {
-          examples.push({ ...newExample });
+          examples.push({
+            name: "generated-example",
+            params: [
+              {
+                name: param.name,
+                value: ex,
+              },
+            ],
+            result: {
+              name: "example-result",
+              value: null,
+            },
+          });
+        } else {
+          examples[i].params.push({
+            name: param.name,
+            value: ex,
+          });
         }
-        examples[i].params.push({
-          name: param.name,
-          value: ex,
-        });
       });
     }
   });
@@ -46,12 +50,20 @@ const getExamplesFromMethod = (method?: MethodObject): ExamplePairingObject[] =>
   if (methodResult && methodResult.schema && methodResult.schema.examples && methodResult.schema.examples.length > 0) {
     methodResult.schema.examples.forEach((ex: any, i: number) => {
       if (!examples[i]) {
-        examples.push({ ...newExample });
+        examples.push({
+          name: "generated-example",
+          params: [],
+          result: {
+            name: methodResult.name,
+            value: ex,
+          },
+        });
+      } else {
+        examples[i].result = {
+          name: methodResult.name,
+          value: ex,
+        };
       }
-      examples[i].result = {
-        name: methodResult.name,
-        value: ex,
-      };
     });
   }
   return examples;


### PR DESCRIPTION
fixes a bug where it would mutate the underlying `.params` array instead of copying a new one